### PR TITLE
QAT for Cosmic Tagger

### DIFF
--- a/bin/exec.py
+++ b/bin/exec.py
@@ -100,6 +100,7 @@ class exec(object):
         self.make_trainer()
 
         self.trainer.initialize()
+        self.trainer._net.train()
         self.trainer.batch_process()
 
 

--- a/bin/exec.py
+++ b/bin/exec.py
@@ -100,7 +100,6 @@ class exec(object):
         self.make_trainer()
 
         self.trainer.initialize()
-        self.trainer._net.train()
         self.trainer.batch_process()
 
 
@@ -245,7 +244,13 @@ class exec(object):
                 logger.warning("Torch requires channels_first, switching automatically")
                 self.args.data.data_format = DataFormatKind.channels_first
 
+        elif self.args.framework.name == "tensorflow":
+            if self.args.mode.name == ModeKind.train:
+                if self.args.mode.quantization_aware:
+                    logger.error("Quantization aware training not implemented in tensorflow.")
+
         self.args.network.data_format = self.args.data.data_format.name
+
 
 
 

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -40,6 +40,7 @@ class Run:
     id:                 str         = MISSING
     precision:          Precision   = Precision.float32
     profile:            bool        = False
+    img_transform:      bool        = False
 
 cs = ConfigStore.instance()
 

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -40,7 +40,6 @@ class Run:
     id:                 str         = MISSING
     precision:          Precision   = Precision.float32
     profile:            bool        = False
-    img_transform:      bool        = False
 
 cs = ConfigStore.instance()
 

--- a/src/config/data.py
+++ b/src/config/data.py
@@ -20,6 +20,8 @@ class Real(Data):
     data_directory: str  = "/grand/projects/datascience/cadams/datasets/SBND/"
     file:           str  = "cosmic_tagging_train.h5"
     aux_file:       str  = "cosmic_tagging_val.h5"
+    img_transform:  bool = False
+
 
 
 

--- a/src/config/mode.py
+++ b/src/config/mode.py
@@ -23,6 +23,7 @@ class Train(Mode):
     summary_iteration:      int = 1
     logging_iteration:      int = 1
     optimizer:        Optimizer = Optimizer()
+    quantization_aware:    bool = False
 
 @dataclass
 class Inference(Mode):

--- a/src/utils/core/trainercore.py
+++ b/src/utils/core/trainercore.py
@@ -77,22 +77,22 @@ class trainercore(object):
         if not self.args.data.synthetic and not aux_f.exists():
             if self.is_training():
                 logger.warning("WARNING: Aux file does not exist.  Setting to None for training")
-                self.args.data.aux_file = None
+                self.args.data.aux_file = ""
             else:
                 # In inference mode, we are creating the aux file.  So we need to check
                 # that the directory exists.  Otherwise, no writing.
                 if not aux_f.parent.exists():
                     logger.warning("WARNING: Aux file's directory does not exist.")
-                    self.args.data.aux_file = None
+                    self.args.data.aux_file = ""
                 elif self.args.data.aux_file is None or str(self.args.data.aux_file).lower() == "none":
                     logger.warning("WARNING: no aux file set, so not writing inference results.")
-                    self.args.data.aux_file = None
+                    self.args.data.aux_file = ""
 
 
         self._train_data_size = self.larcv_fetcher.prepare_cosmic_sample(
             "train", f, self.args.run.minibatch_size, color)
 
-        if aux_f is not None:
+        if self.args.data.aux_file != "":
             if self.is_training():
                 # Fetching data for on the fly testing:
                 self._aux_data_size = self.larcv_fetcher.prepare_cosmic_sample(


### PR DESCRIPTION
Working off of 1.1.0 release
- Added QAT for the PyTorch training code for Cosmic Tagger
- Added a new config option for image transforms under run.image_transforms, if set to true the images will be passed in as log(x+1), should try QAT with both img transforms turned on and turned off to see if there's a difference in performance