### PR TITLE
Temporary workaround: Use TensorboardX summary writer for torch trainer

### DIFF
--- a/src/utils/torch/trainer.py
+++ b/src/utils/torch/trainer.py
@@ -40,10 +40,10 @@ def dummycontext():
 
 import datetime
 
-try:
-    from torch.utils.tensorboard import SummaryWriter
-except:
-    from tensorboardX import SummaryWriter
+#try:
+#    from torch.utils.tensorboard import SummaryWriter
+#except:
+from tensorboardX import SummaryWriter
 
 from src.config import ComputeMode, Precision, ConvMode, ModeKind, DataFormatKind
 


### PR DESCRIPTION
Using torch.utils.tensorboard causes malloc segfault with TF=1.12